### PR TITLE
feat: add awards page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-# Site settings30
+# Site settings
 
 title: UT Systems and Storage Lab
 email: vijayc@utexas.edu
@@ -28,6 +28,7 @@ contact: >
 # Pages shown in navbar
 nav_pages:
   - name: publications
+  - name: awards
 #  - name: talks
 #  - name: research
 #  - name: software

--- a/_data/awards.yml
+++ b/_data/awards.yml
@@ -1,10 +1,13 @@
 - name: Best Paper Award at EuroSys 2023
+  paper: chipmunk-eurosys23
 - name: Best Paper Award at ATC 2018
+  paper: HuEtAl18-TxFS
 - name: Best Paper Award at FAST 2018
+  paper: AlagappanEtAl18-FAST
 - name: NSF CAREER Award 2018
 - name: Best Poster Award at ApSys 2017
+  paper: purohith17sqlite
 - name: Best Paper Award at FAST 2017
+  paper: PillaiEtAl17-CCFS
 - name: ACM SIGOPS Dennis M. Ritchie Dissertation Award 2016
-- name: Microsoft Research Graduate Fellowship 2014
-- name: University of Wisconsin-Madison Alumni Scholarship 2009
 

--- a/_layouts/award.html
+++ b/_layouts/award.html
@@ -9,5 +9,10 @@
   {% assign link = site.url | append: site.baseurl | append: '/papers/' | append: entry.file %}
 {% endif %}
 <li>
-  {{ award_name }} for <a href="{{ link }}" target="_blank">{{ entry.title | remove: open_brace | remove: close_brace }}</a>
+  {{ award_name }} for
+  {% if link %}
+    <a href="{{ link }}" target="_blank">{{ entry.title | remove: open_brace | remove: close_brace }}</a>
+  {% else %}
+    {{ entry.title | remove: open_brace | remove: close_brace }}
+  {% endif %}
 </li>

--- a/_layouts/award.html
+++ b/_layouts/award.html
@@ -1,0 +1,13 @@
+---
+---
+{% assign open_brace = '{' %}
+{% assign close_brace = '}' %}
+{% assign link = nil %}
+{% if entry.pdf %}
+  {% assign link = entry.pdf | unescape_tilde %}
+{% elsif entry.file %}
+  {% assign link = site.url | append: site.baseurl | append: '/papers/' | append: entry.file %}
+{% endif %}
+<li>
+  {{ award_name }} for <a href="{{ link }}" target="_blank">{{ entry.title | remove: open_brace | remove: close_brace }}</a>
+</li>

--- a/_pages/awards.md
+++ b/_pages/awards.md
@@ -1,0 +1,20 @@
+---
+title: "Awards"
+layout: gridlay
+sitemap: false
+permalink: /awards/
+---
+
+<p style="font-size: 1.2rem;">Honors and awards received by our group and its members.</p>
+
+<ul style="font-size: 1.2rem;">
+{% for award in site.data.awards %}
+  {% if award.paper %}
+    {% assign award_name = award.name %}
+    {% bibliography --template award --query @*[key={{ award.paper }}] %}
+  {% else %}
+    <li>{{ award.name }}</li>
+  {% endif %}
+{% endfor %}
+</ul>
+

--- a/_pages/awards.md
+++ b/_pages/awards.md
@@ -11,7 +11,7 @@ permalink: /awards/
 {% for award in site.data.awards %}
   {% if award.paper %}
     {% assign award_name = award.name %}
-    {% bibliography --template award --query @*[key={{ award.paper }}] %}
+    {% bibliography --template award --query "@*[key={{award.paper}}]" %}
   {% else %}
     <li>{{ award.name }}</li>
   {% endif %}


### PR DESCRIPTION
## Summary
- add Awards page pulling data from `awards.yml`
- expose Awards page in navigation
- populate `awards.yml` with Awards section from About page
- link award entries to relevant papers in `ref.bib`

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a59966188325a56a67755088359c